### PR TITLE
Remove unused xlsxwriter import

### DIFF
--- a/redline.py
+++ b/redline.py
@@ -14,7 +14,6 @@ from typing import IO, List
 import numpy as np
 import pandas as pd
 import streamlit as st
-import xlsxwriter
 
 
 # ───────────────────────── CONFIG ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove unused `xlsxwriter` import from `redline.py`

## Testing
- `python -m py_compile redline.py`
